### PR TITLE
:heavy_minus_sign: Remove libudev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.203", optional = true, features = ["derive"] }
 serde_ini = { version = "0.2.0", optional = true }
 serde_bytes = { version = "0.11.15", optional = true }
 uuid = { version = "1.8.0", optional = true }
-serialport = { version = "4.5.0", optional = true, features = ["usbportinfo-interface"] }
+serialport = { version = "4.5.0", optional = true, features = ["usbportinfo-interface"], default_features = false}
 tokio = { version = "1.23.0", features = ["full"], optional = true }
 tokio-serial = { version = "5.4.4", default-features = false, optional = true }
 image = { version = "0.25.1", optional = true }


### PR DESCRIPTION
Enables cargo-v5 and vex-v5-serial to be used in places where libudev is not available.
My use case was not wanting to install libudev in my devcontainer, but I'm sure there's much better reasons.

It does seem to work, but I have yet to fully test it and idrk what should be done to fully test it.