### PR TITLE
docs: fill in "unknown" comment

### DIFF
--- a/src/packets/file.rs
+++ b/src/packets/file.rs
@@ -98,7 +98,10 @@ pub enum ExtensionType {
     #[default]
     Binary = 0x0,
 
-    /// Unknown use
+    /// A file which depends on a VM.
+    /// 
+    /// This is the file type used for VEXCode Python bin uploads, since they need the
+    /// Python VM to function.
     Vm = 0x61,
 
     /// File's contents is encrypted.


### PR DESCRIPTION
There was a comment on `ExtensionType::Vm` that said "Unknown use". I found the use, so I changed the comment.

Try doing `cargo v5 ls` on a brain with a VEXCode Python upload and you can see where I got this from.